### PR TITLE
Enhanced JSON input

### DIFF
--- a/CiteprocRsKit.xcodeproj/project.pbxproj
+++ b/CiteprocRsKit.xcodeproj/project.pbxproj
@@ -21,6 +21,8 @@
 		857D733C26B1320100C34654 /* Buffer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 857D733B26B1320100C34654 /* Buffer.swift */; };
 		8583B29A26B7F26F007FF5AB /* ClusterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8583B29926B7F26F007FF5AB /* ClusterTests.swift */; };
 		8583B29C26B80563007FF5AB /* PanicTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8583B29B26B80563007FF5AB /* PanicTests.swift */; };
+		8593921E26DDFE1000540770 /* CslJson.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8593921D26DDFE1000540770 /* CslJson.swift */; };
+		8593922026DDFED200540770 /* CslJsonTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8593921F26DDFED200540770 /* CslJsonTests.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -61,6 +63,12 @@
 		857D733B26B1320100C34654 /* Buffer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Buffer.swift; sourceTree = "<group>"; };
 		8583B29926B7F26F007FF5AB /* ClusterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClusterTests.swift; sourceTree = "<group>"; };
 		8583B29B26B80563007FF5AB /* PanicTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PanicTests.swift; sourceTree = "<group>"; };
+		8593921D26DDFE1000540770 /* CslJson.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CslJson.swift; sourceTree = "<group>"; };
+		8593921F26DDFED200540770 /* CslJsonTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CslJsonTests.swift; sourceTree = "<group>"; };
+		85A2F50D260C38BD00B8DCE6 /* Link-citeproc-rs.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = "Link-citeproc-rs.xcconfig"; sourceTree = "<group>"; };
+		85E4B4D2260D99E4001B9ED1 /* Release.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Release.xcconfig; sourceTree = "<group>"; };
+		85E4B4E1260D9DA7001B9ED1 /* Common.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Common.xcconfig; sourceTree = "<group>"; };
+		85E4B4E4260D9E1A001B9ED1 /* Debug.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Debug.xcconfig; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -106,6 +114,7 @@
 		851A493C260AD10B00AD1322 /* CiteprocRsKit */ = {
 			isa = PBXGroup;
 			children = (
+				8593921D26DDFE1000540770 /* CslJson.swift */,
 				851A495F260AD3EE00AD1322 /* Info.plist */,
 				851A4954260AD12300AD1322 /* Driver.swift */,
 				854805BF26B86814000E2E55 /* Cluster.swift */,
@@ -128,6 +137,7 @@
 				8583B29B26B80563007FF5AB /* PanicTests.swift */,
 				851A494A260AD10B00AD1322 /* Info.plist */,
 				853851B826C1704600EDBDE0 /* LoggerTests.swift */,
+				8593921F26DDFED200540770 /* CslJsonTests.swift */,
 			);
 			path = CiteprocRsKitTests;
 			sourceTree = "<group>";
@@ -288,6 +298,7 @@
 				853851B726C16AF400EDBDE0 /* Logger.swift in Sources */,
 				852DD4AE26B15497002AED8D /* FetchContext.swift in Sources */,
 				852DD4B226B3E410002AED8D /* FFIUserData.swift in Sources */,
+				8593921E26DDFE1000540770 /* CslJson.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -299,6 +310,7 @@
 				8583B29A26B7F26F007FF5AB /* ClusterTests.swift in Sources */,
 				8583B29C26B80563007FF5AB /* PanicTests.swift in Sources */,
 				852DD4B426B3E733002AED8D /* MemoryTests.swift in Sources */,
+				8593922026DDFED200540770 /* CslJsonTests.swift in Sources */,
 				851A4949260AD10B00AD1322 /* CiteprocRsKitTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/CiteprocRsKit.xcodeproj/project.pbxproj
+++ b/CiteprocRsKit.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 50;
+	objectVersion = 52;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -18,6 +18,8 @@
 		853851B926C1704600EDBDE0 /* LoggerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 853851B826C1704600EDBDE0 /* LoggerTests.swift */; };
 		854805C026B86814000E2E55 /* Cluster.swift in Sources */ = {isa = PBXBuildFile; fileRef = 854805BF26B86814000E2E55 /* Cluster.swift */; };
 		854CF4A626CAD5EE00363E4B /* Documentation.docc in Sources */ = {isa = PBXBuildFile; fileRef = 854CF4A526CAD5EE00363E4B /* Documentation.docc */; };
+		8552F5FB26E261B800F54483 /* CiteprocRs.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8552F5F926E2618700F54483 /* CiteprocRs.xcframework */; };
+		8552F5FC26E261B800F54483 /* CiteprocRs.xcframework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 8552F5F926E2618700F54483 /* CiteprocRs.xcframework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		857D733C26B1320100C34654 /* Buffer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 857D733B26B1320100C34654 /* Buffer.swift */; };
 		8583B29A26B7F26F007FF5AB /* ClusterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8583B29926B7F26F007FF5AB /* ClusterTests.swift */; };
 		8583B29C26B80563007FF5AB /* PanicTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8583B29B26B80563007FF5AB /* PanicTests.swift */; };
@@ -42,15 +44,27 @@
 		};
 /* End PBXContainerItemProxy section */
 
+/* Begin PBXCopyFilesBuildPhase section */
+		8552F5FD26E261B800F54483 /* Embed Frameworks */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "";
+			dstSubfolderSpec = 10;
+			files = (
+				8552F5FC26E261B800F54483 /* CiteprocRs.xcframework in Embed Frameworks */,
+			);
+			name = "Embed Frameworks";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXCopyFilesBuildPhase section */
+
 /* Begin PBXFileReference section */
-		8518340826DF8C4900F7A1DE /* CiteprocRs.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = CiteprocRs.xcframework; path = "citeproc-rs/target/xcframework/debug/CiteprocRs.xcframework"; sourceTree = "<group>"; };
 		851A493B260AD10B00AD1322 /* CiteprocRsKit.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = CiteprocRsKit.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		851A4948260AD10B00AD1322 /* CiteprocRsKitTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CiteprocRsKitTests.swift; sourceTree = "<group>"; };
 		851A494A260AD10B00AD1322 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		851A4954260AD12300AD1322 /* Driver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Driver.swift; sourceTree = "<group>"; };
 		851A495A260AD31D00AD1322 /* CiteprocRsKitTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = CiteprocRsKitTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		851A495F260AD3EE00AD1322 /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
-		851F28B226E209210010D76E /* Configuration */ = {isa = PBXFileReference; lastKnownFileType = folder; path = Configuration; sourceTree = "<group>"; };
 		852DD4AD26B15497002AED8D /* FetchContext.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FetchContext.swift; sourceTree = "<group>"; };
 		852DD4AF26B154BC002AED8D /* Errors.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Errors.swift; sourceTree = "<group>"; };
 		852DD4B126B3E410002AED8D /* FFIUserData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FFIUserData.swift; sourceTree = "<group>"; };
@@ -59,16 +73,17 @@
 		853851B826C1704600EDBDE0 /* LoggerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoggerTests.swift; sourceTree = "<group>"; };
 		854805BF26B86814000E2E55 /* Cluster.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Cluster.swift; sourceTree = "<group>"; };
 		854CF4A526CAD5EE00363E4B /* Documentation.docc */ = {isa = PBXFileReference; lastKnownFileType = folder.documentationcatalog; path = Documentation.docc; sourceTree = "<group>"; };
+		8552F5F526E2611D00F54483 /* Common.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Common.xcconfig; sourceTree = "<group>"; };
+		8552F5F626E2611D00F54483 /* Debug.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Debug.xcconfig; sourceTree = "<group>"; };
+		8552F5F726E2611D00F54483 /* Release.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Release.xcconfig; sourceTree = "<group>"; };
+		8552F5F826E2611D00F54483 /* Link-citeproc-rs.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = "Link-citeproc-rs.xcconfig"; sourceTree = "<group>"; };
+		8552F5F926E2618700F54483 /* CiteprocRs.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = CiteprocRs.xcframework; path = "citeproc-rs/target/xcframework/debug/CiteprocRs.xcframework"; sourceTree = "<group>"; };
 		856B441926086D410088EBFC /* Scripts */ = {isa = PBXFileReference; lastKnownFileType = folder; path = Scripts; sourceTree = "<group>"; };
 		857D733B26B1320100C34654 /* Buffer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Buffer.swift; sourceTree = "<group>"; };
 		8583B29926B7F26F007FF5AB /* ClusterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClusterTests.swift; sourceTree = "<group>"; };
 		8583B29B26B80563007FF5AB /* PanicTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PanicTests.swift; sourceTree = "<group>"; };
 		8593921D26DDFE1000540770 /* CslJson.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CslJson.swift; sourceTree = "<group>"; };
 		8593921F26DDFED200540770 /* CslJsonTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CslJsonTests.swift; sourceTree = "<group>"; };
-		85A2F50D260C38BD00B8DCE6 /* Link-citeproc-rs.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = "Link-citeproc-rs.xcconfig"; sourceTree = "<group>"; };
-		85E4B4D2260D99E4001B9ED1 /* Release.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Release.xcconfig; sourceTree = "<group>"; };
-		85E4B4E1260D9DA7001B9ED1 /* Common.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Common.xcconfig; sourceTree = "<group>"; };
-		85E4B4E4260D9E1A001B9ED1 /* Debug.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Debug.xcconfig; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -76,6 +91,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				8552F5FB26E261B800F54483 /* CiteprocRs.xcframework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -93,12 +109,13 @@
 		850B71CF26085A0200EB37D0 = {
 			isa = PBXGroup;
 			children = (
-				851F28B226E209210010D76E /* Configuration */,
-				8518340826DF8C4900F7A1DE /* CiteprocRs.xcframework */,
+				8552F5F926E2618700F54483 /* CiteprocRs.xcframework */,
+				8552F5F426E2611D00F54483 /* Configuration */,
 				8518340726DF827C00F7A1DE /* Sources */,
 				856B441926086D410088EBFC /* Scripts */,
 				851A493B260AD10B00AD1322 /* CiteprocRsKit.framework */,
 				851A495A260AD31D00AD1322 /* CiteprocRsKitTests.xctest */,
+				8552F5FA26E261B800F54483 /* Frameworks */,
 			);
 			sourceTree = "<group>";
 		};
@@ -140,6 +157,24 @@
 				8593921F26DDFED200540770 /* CslJsonTests.swift */,
 			);
 			path = CiteprocRsKitTests;
+			sourceTree = "<group>";
+		};
+		8552F5F426E2611D00F54483 /* Configuration */ = {
+			isa = PBXGroup;
+			children = (
+				8552F5F526E2611D00F54483 /* Common.xcconfig */,
+				8552F5F626E2611D00F54483 /* Debug.xcconfig */,
+				8552F5F726E2611D00F54483 /* Release.xcconfig */,
+				8552F5F826E2611D00F54483 /* Link-citeproc-rs.xcconfig */,
+			);
+			path = Configuration;
+			sourceTree = "<group>";
+		};
+		8552F5FA26E261B800F54483 /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			name = Frameworks;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -194,6 +229,7 @@
 				851A4937260AD10B00AD1322 /* Sources */,
 				851A4938260AD10B00AD1322 /* Frameworks */,
 				851A4939260AD10B00AD1322 /* Resources */,
+				8552F5FD26E261B800F54483 /* Embed Frameworks */,
 			);
 			buildRules = (
 			);
@@ -333,6 +369,7 @@
 /* Begin XCBuildConfiguration section */
 		850B71DD26085A0200EB37D0 /* Debug */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 8552F5F626E2611D00F54483 /* Debug.xcconfig */;
 			buildSettings = {
 				CLANG_ANALYZER_NONNULL = YES;
 				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
@@ -390,6 +427,7 @@
 		};
 		850B71DE26085A0200EB37D0 /* Release */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 8552F5F726E2611D00F54483 /* Release.xcconfig */;
 			buildSettings = {
 				CLANG_ANALYZER_NONNULL = YES;
 				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;

--- a/Sources/CiteprocRsKit/CslJson.swift
+++ b/Sources/CiteprocRsKit/CslJson.swift
@@ -78,7 +78,6 @@ public enum CslVariable: Encodable {
     case number(NumString)
     case names([CslName])
     case date(CslDate)
-    /// CSL 1.1
     case title(CslTitle)
 
     public func encode(to encoder: Encoder) throws {
@@ -210,9 +209,11 @@ public enum CslDate: Encodable {
 
 public enum CslTitle: Encodable {
     case string(String)
-    case object(TitleObject)
+    // enable when supported
+    // case object(TitleObject)
 
-    public struct TitleObject: Encodable {
+    /// Currently unused, as CSL 1.1-style title objects are not yet supported by citeproc-rs
+    internal struct TitleObject: Encodable {
         public init(
             full: String? = nil, main: String? = nil, sub: [String]? = nil, short: String? = nil
         ) {
@@ -231,7 +232,8 @@ public enum CslTitle: Encodable {
     public func encode(to encoder: Encoder) throws {
         switch self {
         case .string(let s): return try s.encode(to: encoder)
-        case .object(let o): return try o.encode(to: encoder)
+        // enable when supported
+        // case .object(let o): return try o.encode(to: encoder)
         }
     }
 }

--- a/Sources/CiteprocRsKit/CslJson.swift
+++ b/Sources/CiteprocRsKit/CslJson.swift
@@ -1,0 +1,146 @@
+//
+//  CslJson.swift
+//  
+//
+//  Created by Cormac Relf on 31/8/21.
+//
+
+import Foundation
+
+// If anyone needs this to be Decodable (unlikely), there's https://paul-samuels.com/blog/2019/01/02/swift-heterogeneous-codable-array/
+// TODO: make this Equatable and Hashable
+public struct CslReference: Encodable {
+    public var id: String
+    public var type: String
+    public var variables: [String: CslVariable]
+
+    public init(id: String, type: String, variables: [String: CslVariable]) {
+        self.id = id
+        self.type = type
+        self.variables = variables
+    }
+    
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(self.id, forKey: CodingKeys.id)
+        try container.encode(self.type, forKey: CodingKeys.type)
+        for (key, variable) in self.variables {
+            try container.encode(variable, forKey: CodingKeys.init(stringValue: key)!)
+        }
+    }
+    
+    enum CodingKeys: CodingKey {
+        var intValue: Int? {
+            return nil
+        }
+        
+        init?(intValue: Int) {
+            return nil
+        }
+        
+        var stringValue: String {
+            switch self {
+            case .id: return "id"
+            case .type: return "type"
+            case .variable(let s): return s
+            }
+        }
+        
+        init?(stringValue: String) {
+            switch stringValue {
+            case "id": self = .id; break
+            case "type": self = .type; break
+            default: self = .variable(stringValue); break
+            }
+        }
+        
+        case id
+        case type
+        case variable(String)
+    }
+}
+
+public enum CslVariable: Encodable {
+    
+    case string(String)
+    case number(NumString)
+    case names([CslName])
+    case date(CslDate)
+    /// CSL 1.1
+    case title(CslTitle)
+    
+    public func encode(to encoder: Encoder) throws {
+        switch self {
+        case .string(let s): try s.encode(to: encoder)
+        case .number(let n): try n.encode(to: encoder)
+        case .names(let n): try n.encode(to: encoder)
+        case .date(let d): try d.encode(to: encoder)
+        case .title(let t): try t.encode(to: encoder)
+        }
+    }
+}
+
+public enum NumString: Encodable {
+    public func encode(to encoder: Encoder) throws {
+        switch self {
+        case .int(let i): try i.encode(to: encoder)
+        case .string(let s): try s.encode(to: encoder)
+        }
+    }
+    case int(Int)
+    case string(String)
+}
+
+public struct CslName: Encodable {
+    public var family: String?
+    public var given: String?
+    
+    public init(family: String? = nil, given: String? = nil) {
+        self.family = family
+        self.given = given
+    }
+}
+
+public enum CslDate: Encodable {
+    case edtf(String)
+    case legacy(Legacy)
+    
+    public struct Legacy: Encodable {
+        public var dateParts: [[Int]]?
+        public var circa: Bool?
+        // TODO: more fields, also circa is called approximate now?
+    }
+    
+    public func encode(to encoder: Encoder) throws {
+        switch self {
+        case .edtf(let edtf): return try edtf.encode(to: encoder)
+        case .legacy(let legacy): return try legacy.encode(to: encoder)
+        }
+    }
+}
+
+public enum CslTitle: Encodable {
+    case string(String)
+    case object(TitleObject)
+    
+    public struct TitleObject: Encodable {
+        public init(full: String? = nil, main: String? = nil, sub: [String]? = nil, short: String? = nil) {
+            self.full = full
+            self.main = main
+            self.sub = sub
+            self.short = short
+        }
+        /// "The full title string for the item; should generally be redundant, as it's simply the main + the sub titles and/or alternate title"
+        public var full: String?
+        public var main: String?
+        public var sub: [String]?
+        public var short: String?
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        switch self {
+        case .string(let s): return try s.encode(to: encoder)
+        case .object(let o): return try o.encode(to: encoder)
+        }
+    }
+}

--- a/Sources/CiteprocRsKit/CslJson.swift
+++ b/Sources/CiteprocRsKit/CslJson.swift
@@ -1,14 +1,15 @@
 //
 //  CslJson.swift
-//  
+//
 //
 //  Created by Cormac Relf on 31/8/21.
 //
 
 import Foundation
 
-// If anyone needs this to be Decodable (unlikely), there's https://paul-samuels.com/blog/2019/01/02/swift-heterogeneous-codable-array/
+// If anyone needs this to be Decodable, there's https://paul-samuels.com/blog/2019/01/02/swift-heterogeneous-codable-array/
 // TODO: make this Equatable and Hashable
+
 public struct CslReference: Encodable {
     public var id: String
     public var type: String
@@ -19,25 +20,30 @@ public struct CslReference: Encodable {
         self.type = type
         self.variables = variables
     }
-    
+
     public func encode(to encoder: Encoder) throws {
         var container = encoder.container(keyedBy: CodingKeys.self)
         try container.encode(self.id, forKey: CodingKeys.id)
         try container.encode(self.type, forKey: CodingKeys.type)
         for (key, variable) in self.variables {
-            try container.encode(variable, forKey: CodingKeys.init(stringValue: key)!)
+            if let key = CodingKeys.init(stringValue: key) {
+                guard case .variable = key else {
+                    continue
+                }
+                try container.encode(variable, forKey: key)
+            }
         }
     }
-    
+
     enum CodingKeys: CodingKey {
         var intValue: Int? {
             return nil
         }
-        
+
         init?(intValue: Int) {
             return nil
         }
-        
+
         var stringValue: String {
             switch self {
             case .id: return "id"
@@ -45,15 +51,21 @@ public struct CslReference: Encodable {
             case .variable(let s): return s
             }
         }
-        
+
         init?(stringValue: String) {
             switch stringValue {
-            case "id": self = .id; break
-            case "type": self = .type; break
-            default: self = .variable(stringValue); break
+            case "id":
+                self = .id
+                break
+            case "type":
+                self = .type
+                break
+            default:
+                self = .variable(stringValue)
+                break
             }
         }
-        
+
         case id
         case type
         case variable(String)
@@ -61,14 +73,14 @@ public struct CslReference: Encodable {
 }
 
 public enum CslVariable: Encodable {
-    
+
     case string(String)
     case number(NumString)
     case names([CslName])
     case date(CslDate)
     /// CSL 1.1
     case title(CslTitle)
-    
+
     public func encode(to encoder: Encoder) throws {
         switch self {
         case .string(let s): try s.encode(to: encoder)
@@ -92,29 +104,106 @@ public enum NumString: Encodable {
 }
 
 public struct CslName: Encodable {
-    public var family: String?
-    public var given: String?
-    
-    public init(family: String? = nil, given: String? = nil) {
+
+    public init(
+        family: String? = nil, given: String? = nil,
+        droppingParticle: String? = nil, nonDroppingParticle: String? = nil
+    ) {
         self.family = family
         self.given = given
+        self.droppingParticle = droppingParticle
+        self.nonDroppingParticle = nonDroppingParticle
+    }
+
+    public init(
+        literal: String? = nil
+    ) {
+        self.literal = literal
+    }
+
+    public var family: String? = nil
+    public var given: String? = nil
+    public var literal: String? = nil
+    public var droppingParticle: String? = nil
+    public var nonDroppingParticle: String? = nil
+
+    enum CodingKeys: String, CodingKey {
+        case family, given, literal
+        case droppingParticle = "dropping-particle"
+        case nonDroppingParticle = "non-dropping-particle"
     }
 }
 
 public enum CslDate: Encodable {
-    case edtf(String)
-    case legacy(Legacy)
-    
-    public struct Legacy: Encodable {
-        public var dateParts: [[Int]]?
-        public var circa: Bool?
-        // TODO: more fields, also circa is called approximate now?
+
+    // enable when supported
+    // case edtf(String)
+    case v1(V1)
+
+    public struct V1: Encodable {
+
+        public var dateParts: [[Int]]? = nil
+        public var raw: String? = nil
+        public var literal: String? = nil
+        // enable when supported
+        // public var edtf: String?
+
+        public var circa: Bool? = nil
+        public var season: NumString? = nil
+
+        public init(
+            dateParts: [[Int]],
+            circa: Bool? = nil, season: NumString? = nil
+        ) {
+            self.dateParts = dateParts
+            self.circa = circa
+            self.season = season
+        }
+
+        public init(
+            raw: String,
+            circa: Bool? = nil, season: NumString? = nil
+        ) {
+            self.raw = raw
+            self.circa = circa
+            self.season = season
+        }
+
+        public init(
+            literal: String,
+            circa: Bool? = nil, season: NumString? = nil
+        ) {
+            self.literal = literal
+            self.circa = circa
+            self.season = season
+        }
+
+        // A Foundation.Date is pretty annoying for us, because it has no timezone information
+        // and hence we cannot know which zone to render it in. It always includes a time, and this
+        // will end up with off-by-one-day errors.
+
+        // So this kind of method is no good.
+        // /// Make sure you're creating date objects using GMT. Otherwise the rendered date will be wrong.
+        // @available(macOS 10.12, *)
+        // public init(rawFrom date: Date) {
+        //     let fmt = ISO8601DateFormatter()
+        //     fmt.timeZone = .init(secondsFromGMT: 0)
+        //     fmt.formatOptions.remove(.withFullTime)
+        //     let iso = fmt.string(from: date)
+        //     self = V1(raw: iso)
+        // }
+
+        enum CodingKeys: String, CodingKey {
+            case dateParts = "date-parts"
+            case circa, season, literal, raw
+            // case edtf
+        }
     }
-    
+
     public func encode(to encoder: Encoder) throws {
         switch self {
-        case .edtf(let edtf): return try edtf.encode(to: encoder)
-        case .legacy(let legacy): return try legacy.encode(to: encoder)
+        // case .edtf(let edtf): return try edtf.encode(to: encoder)
+        case .v1(let v1): return try v1.encode(to: encoder)
         }
     }
 }
@@ -122,9 +211,11 @@ public enum CslDate: Encodable {
 public enum CslTitle: Encodable {
     case string(String)
     case object(TitleObject)
-    
+
     public struct TitleObject: Encodable {
-        public init(full: String? = nil, main: String? = nil, sub: [String]? = nil, short: String? = nil) {
+        public init(
+            full: String? = nil, main: String? = nil, sub: [String]? = nil, short: String? = nil
+        ) {
             self.full = full
             self.main = main
             self.sub = sub

--- a/Sources/CiteprocRsKit/Driver.swift
+++ b/Sources/CiteprocRsKit/Driver.swift
@@ -87,9 +87,14 @@ public class CRDriver {
 extension CRDriver {
     
     /// Shows what a reference would look like if rendered in a bibliography. The reference must have an `"id"` field but it will not be used.
-    public func previewReference(_ reference: Any, format: CROutputFormat? = nil) throws -> String {
-        let ref_json: Data = try JSONSerialization.data(withJSONObject: reference)
-        let code = ref_json.withCharPointerLen({ buf, bufLen in
+    public func previewReference<R: Encodable>(_ reference: R, format: CROutputFormat? = nil) throws -> String {
+        let json: Data = try JSONEncoder().encode(reference)
+        return try self.previewReference(json: json, format: format)
+    }
+
+    /// Where you have raw JSON already, you can pass it directly to the driver.
+    public func previewReference(json: Data, format: CROutputFormat? = nil) throws -> String {
+        let code = json.withCharPointerLen({ buf, bufLen in
             citeproc_rs_driver_preview_reference(
                 driver: self.raw,
                 ref_json: buf, ref_json_len: bufLen,
@@ -101,15 +106,21 @@ extension CRDriver {
     }
 
     /// Add a Reference to the Driver.
-    public func insertReference(_ reference: Any) throws {
-        let ref_json: Data = try JSONSerialization.data(withJSONObject: reference)
-        let code = ref_json.withCharPointerLen({ buf, buf_len in
+    public func insertReference<R: Encodable>(_ reference: R) throws {
+        let encoder = JSONEncoder()
+        let json: Data = try encoder.encode(reference)
+        return try self.insertReference(json: json)
+    }
+
+    /// Where you have raw JSON already, you can pass it directly to the driver.
+    public func insertReference(json: Data) throws {
+        let code = json.withCharPointerLen({ buf, buf_len in
             citeproc_rs_driver_insert_reference(
                 driver: self.raw, ref_json: buf, ref_json_len: buf_len)
         })
         try CRError.maybe_throw(returned: code)
     }
-    
+
     /// Concatenates all the bibliography entries into one string.
     public func formatBibliography() throws -> String {
         let code = CiteprocRs.citeproc_rs_driver_format_bibliography(driver: self.raw, user_buf: &self.buffer)

--- a/Sources/CiteprocRsKit/Driver.swift
+++ b/Sources/CiteprocRsKit/Driver.swift
@@ -30,6 +30,7 @@ public class CRDriver {
     private let fetch_ctx: FFIUserData<FetchContext>
     internal var buffer: UTF8Buffer
     private let outputFormat: CROutputFormat
+    private let jsonEncoder: JSONEncoder = JSONEncoder()
 
     private init(raw: OpaquePointer, fetch_ctx: FFIUserData<FetchContext>, outputFormat: CROutputFormat) {
         self.raw = raw
@@ -88,7 +89,7 @@ extension CRDriver {
     
     /// Shows what a reference would look like if rendered in a bibliography. The reference must have an `"id"` field but it will not be used.
     public func previewReference<R: Encodable>(_ reference: R, format: CROutputFormat? = nil) throws -> String {
-        let json: Data = try JSONEncoder().encode(reference)
+        let json: Data = try self.jsonEncoder.encode(reference)
         return try self.previewReference(json: json, format: format)
     }
 
@@ -107,8 +108,7 @@ extension CRDriver {
 
     /// Add a Reference to the Driver.
     public func insertReference<R: Encodable>(_ reference: R) throws {
-        let encoder = JSONEncoder()
-        let json: Data = try encoder.encode(reference)
+        let json: Data = try self.jsonEncoder.encode(reference)
         return try self.insertReference(json: json)
     }
 

--- a/Sources/CiteprocRsKitTests/CiteprocRsKitTests.swift
+++ b/Sources/CiteprocRsKitTests/CiteprocRsKitTests.swift
@@ -196,7 +196,7 @@ class CiteprocRsKitTests: XCTestCase {
         try driver.insertReference(["id": "refid", "type": "book", "title": "The title is here"])
         do {
             // missing required id field
-            try driver.insertReference([:])
+            try driver.insertReference(["type":"book"])
         } catch let e as CRError {
             print(e)
             XCTAssertEqual(e.code, CRErrorCode.serdeJson)

--- a/Sources/CiteprocRsKitTests/ClusterTests.swift
+++ b/Sources/CiteprocRsKitTests/ClusterTests.swift
@@ -64,12 +64,22 @@ class ClusterTests: XCTestCase {
         var document: [CRClusterPosition] = []
         var refids: [String] = []
         let references = [
-            ["id": "ref-1", "type": "book", "title": "A Flight of Sparrows", "author": [["given": "John", "family": "Smith"]] ],
-            ["id": "ref-2", "type": "book", "title": "Seminal works, and how to write them", "author": [["given": "John", "family": "Smith"]]]
+            CslReference(id: "ref-1", type: "book", variables: [
+                "title": .string("A Flight of Sparrows"),
+                "author": .names([
+                    CslName(family: "Smith", given: "John"),
+                ]),
+            ]),
+            CslReference(id: "ref-2", type: "book", variables: [
+                "title": .string("Seminal works, and how to write them"),
+                "author": .names([
+                    CslName(family: "Smith", given: "John"),
+                ]),
+            ]),
         ]
         for refr in references {
             try driver.insertReference(refr)
-            refids.append(refr["id"]! as! String)
+            refids.append(refr.id)
         }
         
         var nextClusterId = CRClusterId(0) // we'll reset the handle before we use the zero id

--- a/Sources/CiteprocRsKitTests/CslJsonTests.swift
+++ b/Sources/CiteprocRsKitTests/CslJsonTests.swift
@@ -48,17 +48,18 @@ final class CslJsonTests: XCTestCase {
             """)
     }
 
-    func testTitles() throws {
-        let variable: CslVariable = .title(.object(.init(full: "Main Title: Subtitle")))
-        let result = try encoder.encode(variable)
-        XCTAssertEqual(
-            String(data: result, encoding: .utf8)!,
-            """
-            {
-              "full" : "Main Title: Subtitle"
-            }
-            """)
-    }
+    // enable when supported
+    // func testTitles() throws {
+    //     let variable: CslVariable = .title(.object(.init(full: "Main Title: Subtitle")))
+    //     let result = try encoder.encode(variable)
+    //     XCTAssertEqual(
+    //         String(data: result, encoding: .utf8)!,
+    //         """
+    //         {
+    //           "full" : "Main Title: Subtitle"
+    //         }
+    //         """)
+    // }
 
     func testDateParts() throws {
         let variable: CslVariable = .date(.v1(.init(dateParts: [[2021, 2, 1]])))

--- a/Sources/CiteprocRsKitTests/CslJsonTests.swift
+++ b/Sources/CiteprocRsKitTests/CslJsonTests.swift
@@ -14,7 +14,7 @@ final class CslJsonTests: XCTestCase {
     var encoder: JSONEncoder = JSONEncoder()
     override func setUp() {
         // for reliable tests
-        encoder.outputFormatting = .sortedKeys
+        encoder.outputFormatting = .prettyPrinted.union(.sortedKeys)
     }
     func testStringVariable() throws {
         let variable: CslVariable = .string("hello");
@@ -24,16 +24,23 @@ final class CslJsonTests: XCTestCase {
     func testNameVariable() throws {
         let variable: CslVariable = .names([CslName(family: "Smith", given: "John")]);
         let result = try encoder.encode(variable)
-        XCTAssertEqual(String(data: result, encoding: .utf8), """
-            [{"family":"Smith","given":"John"}]
+        XCTAssertEqual(String(data: result, encoding: .utf8)!, """
+            [
+              {
+                "family" : "Smith",
+                "given" : "John"
+              }
+            ]
             """)
     }
     
     func testTitles() throws {
         let variable: CslVariable = .title(.object(.init(full: "Main Title: Subtitle")))
         let result = try encoder.encode(variable)
-        XCTAssertEqual(String(data: result, encoding: .utf8), """
-            {"full":"Main Title: Subtitle"}
+        XCTAssertEqual(String(data: result, encoding: .utf8)!, """
+            {
+              "full" : "Main Title: Subtitle"
+            }
             """)
     }
 
@@ -45,8 +52,20 @@ final class CslJsonTests: XCTestCase {
             "title": .string("Title"),
         ])
         let result = try encoder.encode(reference)
-        XCTAssertEqual(String(data: result, encoding: .utf8), """
-            {"author":[{"family":"Smith","given":"John"}],"id":"id","issued":"2021","title":"Title","type":"book","version":2}
+        XCTAssertEqual(String(data: result, encoding: .utf8)!, """
+            {
+              "author" : [
+                {
+                  "family" : "Smith",
+                  "given" : "John"
+                }
+              ],
+              "id" : "id",
+              "issued" : "2021",
+              "title" : "Title",
+              "type" : "book",
+              "version" : 2
+            }
             """)
     }
     

--- a/Sources/CiteprocRsKitTests/CslJsonTests.swift
+++ b/Sources/CiteprocRsKitTests/CslJsonTests.swift
@@ -1,0 +1,54 @@
+//
+//  CslJsonTests.swift
+//  CiteprocRsKitTests
+//
+//  Created by Cormac Relf on 31/8/21.
+//
+
+import Foundation
+import XCTest
+import CiteprocRsKit
+
+@available(macOS 10.13, *) // .sortedKeys
+final class CslJsonTests: XCTestCase {
+    var encoder: JSONEncoder = JSONEncoder()
+    override func setUp() {
+        // for reliable tests
+        encoder.outputFormatting = .sortedKeys
+    }
+    func testStringVariable() throws {
+        let variable: CslVariable = .string("hello");
+        let result = try encoder.encode(variable)
+        XCTAssertEqual(String(data: result, encoding: .utf8), "\"hello\"")
+    }
+    func testNameVariable() throws {
+        let variable: CslVariable = .names([CslName(family: "Smith", given: "John")]);
+        let result = try encoder.encode(variable)
+        XCTAssertEqual(String(data: result, encoding: .utf8), """
+            [{"family":"Smith","given":"John"}]
+            """)
+    }
+    
+    func testTitles() throws {
+        let variable: CslVariable = .title(.object(.init(full: "Main Title: Subtitle")))
+        let result = try encoder.encode(variable)
+        XCTAssertEqual(String(data: result, encoding: .utf8), """
+            {"full":"Main Title: Subtitle"}
+            """)
+    }
+
+    func testReference() throws {
+        let reference: CslReference = CslReference(id: "id", type: "book", variables: [
+            "author": .names([CslName(family: "Smith", given: "John")]),
+            "issued": .date(.edtf("2021")),
+            "version": .number(.int(2)),
+            "title": .string("Title"),
+        ])
+        let result = try encoder.encode(reference)
+        XCTAssertEqual(String(data: result, encoding: .utf8), """
+            {"author":[{"family":"Smith","given":"John"}],"id":"id","issued":"2021","title":"Title","type":"book","version":2}
+            """)
+    }
+    
+    
+}

--- a/Sources/CiteprocRsKitTests/CslJsonTests.swift
+++ b/Sources/CiteprocRsKitTests/CslJsonTests.swift
@@ -5,26 +5,30 @@
 //  Created by Cormac Relf on 31/8/21.
 //
 
+import CiteprocRsKit
 import Foundation
 import XCTest
-import CiteprocRsKit
 
-@available(macOS 10.13, *) // .sortedKeys
+@available(macOS 10.15, *)  // .sortedKeys, .withoutEscapingSlashes
 final class CslJsonTests: XCTestCase {
     var encoder: JSONEncoder = JSONEncoder()
     override func setUp() {
         // for reliable tests
-        encoder.outputFormatting = .prettyPrinted.union(.sortedKeys)
+        encoder.outputFormatting = .prettyPrinted.union(.sortedKeys).union(.withoutEscapingSlashes)
     }
+
     func testStringVariable() throws {
-        let variable: CslVariable = .string("hello");
+        let variable: CslVariable = .string("hello")
         let result = try encoder.encode(variable)
         XCTAssertEqual(String(data: result, encoding: .utf8), "\"hello\"")
     }
+
     func testNameVariable() throws {
-        let variable: CslVariable = .names([CslName(family: "Smith", given: "John")]);
+        let variable: CslVariable = .names([CslName(family: "Smith", given: "John")])
         let result = try encoder.encode(variable)
-        XCTAssertEqual(String(data: result, encoding: .utf8)!, """
+        XCTAssertEqual(
+            String(data: result, encoding: .utf8)!,
+            """
             [
               {
                 "family" : "Smith",
@@ -33,26 +37,60 @@ final class CslJsonTests: XCTestCase {
             ]
             """)
     }
-    
+
+    func testTitleString() throws {
+        let variable: CslVariable = .title(.string("Main Title: Subtitle"))
+        let result = try encoder.encode(variable)
+        XCTAssertEqual(
+            String(data: result, encoding: .utf8)!,
+            """
+            "Main Title: Subtitle"
+            """)
+    }
+
     func testTitles() throws {
         let variable: CslVariable = .title(.object(.init(full: "Main Title: Subtitle")))
         let result = try encoder.encode(variable)
-        XCTAssertEqual(String(data: result, encoding: .utf8)!, """
+        XCTAssertEqual(
+            String(data: result, encoding: .utf8)!,
+            """
             {
               "full" : "Main Title: Subtitle"
             }
             """)
     }
 
+    func testDateParts() throws {
+        let variable: CslVariable = .date(.v1(.init(dateParts: [[2021, 2, 1]])))
+        let result = try encoder.encode(variable)
+        XCTAssertEqual(
+            String(data: result, encoding: .utf8)!,
+            """
+            {
+              "date-parts" : [
+                [
+                  2021,
+                  2,
+                  1
+                ]
+              ]
+            }
+            """)
+    }
+
     func testReference() throws {
-        let reference: CslReference = CslReference(id: "id", type: "book", variables: [
-            "author": .names([CslName(family: "Smith", given: "John")]),
-            "issued": .date(.edtf("2021")),
-            "version": .number(.int(2)),
-            "title": .string("Title"),
-        ])
+        let reference: CslReference = CslReference(
+            id: "id", type: "book",
+            variables: [
+                "author": .names([CslName(family: "Smith", given: "John")]),
+                "issued": .date(.v1(.init(raw: "2021"))),
+                "version": .number(.int(2)),
+                "title": .string("Title"),
+            ])
         let result = try encoder.encode(reference)
-        XCTAssertEqual(String(data: result, encoding: .utf8)!, """
+        XCTAssertEqual(
+            String(data: result, encoding: .utf8)!,
+            """
             {
               "author" : [
                 {
@@ -61,13 +99,32 @@ final class CslJsonTests: XCTestCase {
                 }
               ],
               "id" : "id",
-              "issued" : "2021",
+              "issued" : {
+                "raw" : "2021"
+              },
               "title" : "Title",
               "type" : "book",
               "version" : 2
             }
             """)
     }
-    
-    
+
+    func testBadVarName() throws {
+        let reference: CslReference = CslReference(
+            id: "id", type: "book",
+            variables: [
+                "id": .string("String"),
+                "type": .string("String"),
+            ])
+        let result = try encoder.encode(reference)
+        XCTAssertEqual(
+            String(data: result, encoding: .utf8)!,
+            """
+            {
+              "id" : "id",
+              "type" : "book"
+            }
+            """)
+    }
+
 }


### PR DESCRIPTION

- Allows passing encoded JSON as `Data` to the insert/preview reference methods
- For encoding on the fly, drops JSONSerialization in favour of Swift `Encodable` because heterogeneous dictionaries are too annoying
- Add encodable CslReference, CslVariable, etc types
- Little test suite for the JSON output

